### PR TITLE
refactor(auth): remove multi-account support, cache profile avatar

### DIFF
--- a/sidepanel/sidepanel.css
+++ b/sidepanel/sidepanel.css
@@ -1893,58 +1893,6 @@ input {
   font-size: 10px;
 }
 
-.account-controls {
-  margin-top: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.account-controls label {
-  font-size: 10px;
-  color: var(--text-muted);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.account-select {
-  width: 100%;
-  padding: 9px 12px;
-  background: rgba(237, 236, 233, 0.03);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-input);
-  color: var(--text);
-  font-size: 12px;
-  font-family: 'HarmonyOS Sans', sans-serif;
-}
-
-.account-select:focus {
-  outline: none;
-  border-color: rgba(214, 209, 162, 0.4);
-}
-
-.add-account-panel {
-  margin-top: 12px;
-  padding: 8px 0;
-  background: transparent;
-  border: none;
-  border-radius: 0;
-  display: none;
-}
-
-.add-account-panel.active {
-  display: block;
-}
-
-.account-form-title {
-  margin: 0 0 10px 0;
-  font-size: 11px;
-  color: var(--text-muted);
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
 /* Compact auth login form */
 .auth-login-compact {
   padding: 8px 0;

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -26,7 +26,6 @@ function spError(...args) {
   }
 }
 
-const LEGACY_ACCOUNT_ID = "internal://legacy-account";
 const ALFA_LEETCODE_API_BASE = "https://alfa-leetcode-api.onrender.com";
 
 /* ── Custom Searchable Select Component ── */
@@ -151,8 +150,6 @@ class PopupController {
       isAuthenticated: false,
       user: null,
       token: null,
-      accounts: [],
-      activeAccountId: null,
     };
     this.pendingLeetcodeImport = null;
     this.initialize();
@@ -486,41 +483,6 @@ class PopupController {
     }
   }
 
-  async handleAccountSwitch(event) {
-    const accountId = event?.target?.value;
-    if (!accountId) return;
-    if (typeof extensionAuth === "undefined") {
-      this.showMessage("Account switching is not available - authentication service not loaded.", "error");
-      return;
-    }
-
-    try {
-      await extensionAuth.switchAccount(accountId);
-      const switchedAccount = extensionAuth
-        .getAccounts()
-        .find((account) => account.id === accountId);
-      const switchedName =
-        switchedAccount?.user?.username ||
-        switchedAccount?.user?.displayName ||
-        switchedAccount?.user?.name ||
-        switchedAccount?.user?.email ||
-        "User";
-      this.showMessage(`Switched to ${switchedName}`, "success");
-    } catch (error) {
-      this.showMessage(error?.message || "Failed to switch account.", "error");
-    }
-  }
-
-  toggleAddAccountForm() {
-    const panel = document.getElementById("add-account-panel");
-    if (!panel) return;
-    panel.classList.toggle("active");
-
-    if (!panel.classList.contains("active")) return;
-    const usernameInput = panel.querySelector('input[name="username"]');
-    if (usernameInput) usernameInput.focus();
-  }
-
   toggleAuthLoading(button, isLoading, loadingText = "Working...") {
     if (!button) return;
 
@@ -790,8 +752,6 @@ class PopupController {
 
       // Check local storage for cached auth data first
       const result = await chrome.storage.local.get([
-        "auth_accounts",
-        "auth_active_account_id",
         "auth_user",
         "auth_token",
         "auth_timestamp",
@@ -801,35 +761,7 @@ class PopupController {
       const now = Date.now();
       const maxAge = 24 * 60 * 60 * 1000; // 24 hours
 
-      const hasStoredAccounts =
-        Array.isArray(result.auth_accounts) && result.auth_accounts.length > 0;
-      const activeId = hasStoredAccounts
-        ? result.auth_active_account_id || result.auth_accounts[0]?.id || null
-        : null;
-      const activeAccount = hasStoredAccounts
-        ? result.auth_accounts.find((account) => account.id === activeId) ||
-          result.auth_accounts[0] ||
-          null
-        : null;
-      const activeAccountTimestamp =
-        typeof activeAccount?.timestamp === "number" ? activeAccount.timestamp : null;
-      const activeAccountCacheAge =
-        activeAccountTimestamp !== null ? now - activeAccountTimestamp : maxAge + 1;
-
-      if (
-        activeAccount?.user &&
-        activeAccount?.token &&
-        activeAccountCacheAge < maxAge
-      ) {
-        this.authStatus = {
-          isAuthenticated: true,
-          user: activeAccount.user,
-          token: activeAccount.token,
-          accounts: result.auth_accounts,
-          activeAccountId: activeAccount.id || activeId,
-        };
-        this.updateAuthSection();
-      } else if (result.auth_user && result.auth_timestamp) {
+      if (result.auth_user && result.auth_timestamp) {
         const cacheAge = now - result.auth_timestamp;
         if (cacheAge < maxAge) {
           spLog("[Popup] Found cached backend auth data");
@@ -837,13 +769,6 @@ class PopupController {
             isAuthenticated: true,
             user: result.auth_user,
             token: result.auth_token || null,
-            accounts: [
-              {
-                id: LEGACY_ACCOUNT_ID,
-                user: result.auth_user,
-              },
-            ],
-            activeAccountId: LEGACY_ACCOUNT_ID,
           };
           this.updateAuthSection();
         }
@@ -855,13 +780,6 @@ class PopupController {
             isAuthenticated: true,
             user: result.firebase_user,
             token: result.auth_token || null,
-            accounts: [
-              {
-                id: LEGACY_ACCOUNT_ID,
-                user: result.firebase_user,
-              },
-            ],
-            activeAccountId: LEGACY_ACCOUNT_ID,
           };
           this.updateAuthSection();
         }
@@ -876,10 +794,6 @@ class PopupController {
             isAuthenticated: authStatus.isAuthenticated,
             user: authStatus.user || null,
             token: authStatus.token || null,
-            accounts: Array.isArray(authStatus.accounts)
-              ? authStatus.accounts
-              : [],
-            activeAccountId: authStatus.activeAccountId || null,
           };
           this.updateAuthSection();
           this.updateConnectionStatus();
@@ -931,11 +845,6 @@ class PopupController {
 
     if (isAuthenticated) {
       const user = this.authStatus.user || {};
-      const accountOptions = (this.authStatus.accounts || []).length > 0
-        ? this.authStatus.accounts
-        : [{ id: this.authStatus.activeAccountId || "active-account", user }];
-      const currentAccountId =
-        this.authStatus.activeAccountId || accountOptions[0]?.id;
       const displayName =
         user.username ||
         user.displayName ||
@@ -944,8 +853,15 @@ class PopupController {
         "User";
       const email = user.email || "";
 
-      // Cat profile picture using persisted URL or fallback
-      const avatarUrl = this.config.avatarUrl || `https://robohash.org/${encodeURIComponent(displayName)}?set=set4`;
+      // Profile picture: use persisted URL, or compute+cache a fallback once
+      let avatarUrl = this.config.avatarUrl;
+      if (!avatarUrl) {
+        avatarUrl = `https://robohash.org/${encodeURIComponent(displayName)}?set=set4`;
+        this.config.avatarUrl = avatarUrl;
+        if (typeof chrome !== "undefined" && chrome.storage?.sync) {
+          chrome.storage.sync.set({ avatar_url: avatarUrl });
+        }
+      }
       const avatarMarkup = `<img id="profile-avatar-img" src="${avatarUrl}" alt="${displayName}" />`;
 
       // Get session status for badge
@@ -956,7 +872,7 @@ class PopupController {
         accountSettingsSec.style.display = "none";
       }
 
-      // Render Home tab profile dashboard (large avatar with refresh, displayName, email, badge, actions, and switcher)
+      // Render Home tab profile dashboard (large avatar with refresh, displayName, email, badge, actions)
       authSection.innerHTML = `
         <div class="profile-dashboard">
           <div class="profile-header-card">
@@ -978,41 +894,7 @@ class PopupController {
           </div>
 
           <div class="auth-actions" style="margin-top: 6px;">
-            <button class="btn btn-secondary" id="add-account-btn">Add Account</button>
             <button class="btn btn-secondary" id="sign-out-btn">Sign Out</button>
-          </div>
-
-          <div class="account-controls" style="margin-top: 4px;">
-            <label for="active-account-select" style="display: block; font-size: 11px; color: var(--text-muted); margin-bottom: 6px; letter-spacing: 0.06em; text-transform: uppercase;">Active Account</label>
-            <div class="custom-select" id="active-account-wrapper" data-select-id="active-account-select">
-              <input type="hidden" id="active-account-select" value="" />
-              <button type="button" class="custom-select-trigger" aria-haspopup="listbox">
-                <span class="custom-select-value">Select account</span>
-                <svg class="custom-select-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-              </button>
-              <div class="custom-select-dropdown" role="listbox">
-                <div class="custom-select-search-wrap">
-                  <input type="text" class="custom-select-search" placeholder="Search&hellip;" autocomplete="off" />
-                </div>
-                <div class="custom-select-options"></div>
-              </div>
-            </div>
-          </div>
-
-          <div class="add-account-panel" id="add-account-panel" style="display: none;">
-            <h4 class="account-form-title">Add Another Account</h4>
-            <form class="auth-form active" id="auth-add-account-form" data-form="add-account" aria-label="Add another account">
-              <div class="field" style="margin-bottom: 10px;">
-                <label for="auth-add-username">Username</label>
-                <input type="text" id="auth-add-username" name="username" placeholder="johndoe" autocomplete="username" required />
-              </div>
-              <div class="field" style="margin-bottom: 10px;">
-                <label for="auth-add-password">Password</label>
-                <input type="password" id="auth-add-password" name="password" placeholder="&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;" autocomplete="current-password" required />
-              </div>
-              <button type="submit" class="btn btn-primary">Add Account & Switch</button>
-            </form>
-            <div class="auth-form-message" id="auth-form-message"></div>
           </div>
         </div>
       `;
@@ -1020,38 +902,6 @@ class PopupController {
       const signOutBtn = document.getElementById("sign-out-btn");
       if (signOutBtn) {
         signOutBtn.addEventListener("click", () => this.signOut());
-      }
-      // Initialize custom select for account switcher
-      const accountWrapper = document.getElementById("active-account-wrapper");
-      if (accountWrapper) {
-        const cs = new CustomSelect(accountWrapper);
-        const options = accountOptions.map(account => {
-          const accountName =
-            account?.user?.username ||
-            account?.user?.displayName ||
-            account?.user?.name ||
-            account?.user?.email ||
-            "User";
-          return { value: account.id, label: accountName };
-        });
-        cs.setOptions(options, currentAccountId);
-        // Listen for changes on the hidden input
-        const hiddenInput = document.getElementById("active-account-select");
-        if (hiddenInput) {
-          hiddenInput.addEventListener("change", (event) =>
-            this.handleAccountSwitch(event),
-          );
-        }
-      }
-      const addAccountBtn = document.getElementById("add-account-btn");
-      if (addAccountBtn) {
-        addAccountBtn.addEventListener("click", () => this.toggleAddAccountForm());
-      }
-      const addAccountForm = document.getElementById("auth-add-account-form");
-      if (addAccountForm) {
-        addAccountForm.addEventListener("submit", (event) =>
-          this.handleLoginSubmit(event),
-        );
       }
       const refreshBtn = document.getElementById("avatar-refresh-btn");
       if (refreshBtn) {
@@ -1213,13 +1063,11 @@ class PopupController {
       if (typeof extensionAuth !== "undefined") {
         await extensionAuth.signOut();
         await extensionAuth.requestAuthStatus();
-        this.showMessage("Signed out active account", "success");
-        this.showAuthFeedback("success", "Signed out active account.");
+        this.showMessage("Signed out", "success");
+        this.showAuthFeedback("success", "Signed out.");
       } else {
         // Fallback: clear local storage
         await chrome.storage.local.remove([
-          "auth_accounts",
-          "auth_active_account_id",
           "auth_user",
           "auth_token",
           "auth_timestamp",
@@ -1229,8 +1077,6 @@ class PopupController {
           isAuthenticated: false,
           user: null,
           token: null,
-          accounts: [],
-          activeAccountId: null,
         };
         this.updateAuthSection();
         this.showMessage("Signed out locally", "success");
@@ -1240,8 +1086,6 @@ class PopupController {
       spError("Error signing out:", error);
       // Even if sign out fails, clear local state
       await chrome.storage.local.remove([
-        "auth_accounts",
-        "auth_active_account_id",
         "auth_user",
         "auth_token",
         "auth_timestamp",
@@ -1251,8 +1095,6 @@ class PopupController {
         isAuthenticated: false,
         user: null,
         token: null,
-        accounts: [],
-        activeAccountId: null,
       };
       this.updateAuthSection();
       this.showMessage(

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -97,26 +97,7 @@ async function testPickers() {
   assert.strictEqual(ExtensionAuth.pickUser(null, fallback), fallback);
 }
 
-async function testNormalizeAccountsGuards() {
-  const auth = new ExtensionAuth({ fetch: createMockFetch() });
-
-  assert.deepStrictEqual(auth.normalizeAccounts(null), []);
-  assert.deepStrictEqual(auth.normalizeAccounts({}), []);
-
-  const normalized = auth.normalizeAccounts([
-    null,
-    {},
-    { id: 'missing-user', token: 'abc' },
-    { id: 'missing-token', user: { username: 'x' } },
-    { user: { username: 'ok' }, token: 'ok-token' },
-  ]);
-
-  assert.strictEqual(normalized.length, 1);
-  assert.strictEqual(normalized[0].user.username, 'ok');
-  assert.strictEqual(normalized[0].token, 'ok-token');
-}
-
-async function testLoginStoresActiveAccount() {
+async function testLoginStoresSession() {
   resetStorage();
   const auth = new ExtensionAuth({ fetch: createMockFetch() });
 
@@ -127,98 +108,76 @@ async function testLoginStoresActiveAccount() {
 
   assert.strictEqual(auth.isAuthenticated, true);
   assert.strictEqual(auth.token, 'admin-token');
+  assert.strictEqual(auth.user.username, 'admin');
 
   const stored = await chrome.storage.local.get([
-    'auth_accounts',
-    'auth_active_account_id',
     'auth_user',
     'auth_token',
+    'auth_timestamp',
   ]);
 
-  assert.strictEqual(Array.isArray(stored.auth_accounts), true);
-  assert.strictEqual(stored.auth_accounts.length, 1);
-  assert.strictEqual(stored.auth_accounts[0].user.username, 'admin');
-  assert.strictEqual(
-    Number.isFinite(stored.auth_accounts[0].timestamp),
-    true,
-  );
   assert.strictEqual(stored.auth_user.username, 'admin');
   assert.strictEqual(stored.auth_token, 'admin-token');
-  assert.strictEqual(
-    stored.auth_active_account_id,
-    stored.auth_accounts[0].id,
-  );
+  assert.strictEqual(Number.isFinite(stored.auth_timestamp), true);
 }
 
-async function testSwitchingBetweenMultipleAccounts() {
-  resetStorage();
-  const auth = new ExtensionAuth({ fetch: createMockFetch() });
-
-  await auth.login({
-    username: 'alice',
-    password: 'alice-pass',
-  });
-
-  const aliceId = auth.getAccounts()[0].id;
-
-  await auth.login({
-    username: 'bob',
-    password: 'bob-pass',
-  });
-
-  assert.strictEqual(auth.getAccounts().length, 2);
-  assert.strictEqual(auth.user.username, 'bob');
-
-  await auth.switchAccount(aliceId);
-
-  assert.strictEqual(auth.user.username, 'alice');
-  assert.strictEqual(auth.token, 'alice-token');
-
-  const stored = await chrome.storage.local.get([
-    'auth_active_account_id',
-    'auth_user',
-    'auth_token',
-  ]);
-  assert.strictEqual(stored.auth_active_account_id, aliceId);
-  assert.strictEqual(stored.auth_user.username, 'alice');
-  assert.strictEqual(stored.auth_token, 'alice-token');
-}
-
-async function testSignOutRemovesOnlyActiveAccount() {
+async function testLoggingInAgainReplacesSession() {
   resetStorage();
   const auth = new ExtensionAuth({ fetch: createMockFetch() });
 
   await auth.login({ username: 'alice', password: 'alice-pass' });
-  await auth.login({ username: 'bob', password: 'bob-pass' });
-
-  await auth.signOut();
-
-  assert.strictEqual(auth.isAuthenticated, true);
   assert.strictEqual(auth.user.username, 'alice');
-  assert.strictEqual(auth.getAccounts().length, 1);
 
+  await auth.login({ username: 'bob', password: 'bob-pass' });
+  assert.strictEqual(auth.user.username, 'bob');
+  assert.strictEqual(auth.token, 'bob-token');
+
+  const stored = await chrome.storage.local.get(['auth_user', 'auth_token']);
+  assert.strictEqual(stored.auth_user.username, 'bob');
+  assert.strictEqual(stored.auth_token, 'bob-token');
+}
+
+async function testSignOutClearsSession() {
+  resetStorage();
+  const auth = new ExtensionAuth({ fetch: createMockFetch() });
+
+  await auth.login({ username: 'alice', password: 'alice-pass' });
   await auth.signOut();
 
   assert.strictEqual(auth.isAuthenticated, false);
-  assert.strictEqual(auth.getAccounts().length, 0);
+  assert.strictEqual(auth.user, null);
+  assert.strictEqual(auth.token, null);
 
   const stored = await chrome.storage.local.get([
-    'auth_accounts',
     'auth_user',
     'auth_token',
+    'auth_timestamp',
   ]);
-  assert.strictEqual(stored.auth_accounts, undefined);
   assert.strictEqual(stored.auth_user, undefined);
   assert.strictEqual(stored.auth_token, undefined);
+  assert.strictEqual(stored.auth_timestamp, undefined);
+}
+
+async function testSyncFromStorageRestoresSession() {
+  resetStorage();
+  const seedAuth = new ExtensionAuth({ fetch: createMockFetch() });
+  await seedAuth.login({ username: 'carol', password: 'carol-pass' });
+
+  const restoredAuth = new ExtensionAuth({ fetch: createMockFetch() });
+  await restoredAuth.syncFromStorage();
+
+  assert.strictEqual(restoredAuth.isAuthenticated, true);
+  assert.strictEqual(restoredAuth.user.username, 'carol');
+  assert.strictEqual(restoredAuth.token, 'carol-token');
 }
 
 (async () => {
   try {
     await testPickers();
-    await testNormalizeAccountsGuards();
-    await testLoginStoresActiveAccount();
-    await testSwitchingBetweenMultipleAccounts();
-    await testSignOutRemovesOnlyActiveAccount();
+    await testLoginStoresSession();
+    await testLoggingInAgainReplacesSession();
+    await testSignOutClearsSession();
+    await testSyncFromStorageRestoresSession();
     console.log('Auth tests passed');
   } catch (error) {
     console.error('Auth tests failed:', error);

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -33,8 +33,6 @@ class ExtensionAuth {
     this.user = null;
     this.token = null;
     this.isAuthenticated = false;
-    this.accounts = [];
-    this.activeAccountId = null;
     this.authStatusCallbacks = [];
     this.fetchImpl =
       options.fetch ||
@@ -56,61 +54,13 @@ class ExtensionAuth {
 
     try {
       const data = await chrome.storage.local.get([
-        'auth_accounts',
-        'auth_active_account_id',
         'auth_user',
         'auth_token',
         'auth_timestamp',
       ]);
 
-      const normalizedAccounts = this.normalizeAccounts(data.auth_accounts);
-      if (normalizedAccounts.length > 0) {
-        this.accounts = normalizedAccounts;
-
-        let activeAccount =
-          normalizedAccounts.find((account) => account.id === data.auth_active_account_id) ||
-          normalizedAccounts[0];
-
-        const hasSession = Boolean(activeAccount?.user && activeAccount?.token);
-        this.activeAccountId = activeAccount?.id || null;
-
-        await this.updateAuthStatus(
-          hasSession,
-          hasSession ? activeAccount.user : null,
-          hasSession ? activeAccount.token : null,
-          {
-            persist: false,
-            silent: true,
-            accountId: activeAccount?.id || null,
-            keepAccounts: true,
-          },
-        );
-        return;
-      }
-
       const hasSession = Boolean(data.auth_user && data.auth_token);
-      if (hasSession) {
-        const accountId = this.buildAccountId(data.auth_user);
-        this.accounts = [
-          {
-            id: accountId,
-            user: data.auth_user,
-            token: data.auth_token,
-            timestamp: data.auth_timestamp || Date.now(),
-          },
-        ];
-        this.activeAccountId = accountId;
-        await this.updateAuthStatus(true, data.auth_user, data.auth_token, {
-          persist: false,
-          silent: true,
-          accountId,
-          keepAccounts: true,
-        });
-        await this.persistAuthState();
-        return;
-      }
-
-      await this.updateAuthStatus(false, null, null, {
+      await this.updateAuthStatus(hasSession, data.auth_user || null, data.auth_token || null, {
         persist: false,
         silent: true,
       });
@@ -121,55 +71,6 @@ class ExtensionAuth {
         silent: true,
       });
     }
-  }
-
-  normalizeAccounts(rawAccounts) {
-    if (!Array.isArray(rawAccounts)) return [];
-
-    return rawAccounts
-      .map((account) => {
-        if (!account || typeof account !== 'object') return null;
-        const user = account.user || null;
-        const token = account.token || null;
-        const id = account.id || this.buildAccountId(user);
-
-        if (!user || !token || !id) return null;
-
-        return {
-          id,
-          user,
-          token,
-          timestamp: account.timestamp || Date.now(),
-        };
-      })
-      .filter(Boolean);
-  }
-
-  buildAccountId(user) {
-    const provider = user?.provider || 'backend';
-    const username = user?.username || user?.email || user?.name;
-    let objectFingerprint = 'anonymous';
-    if (user && typeof user === 'object') {
-      const entries = Object.entries(user)
-        .filter(([key, value]) => key !== 'token' && value !== undefined && value !== null)
-        .sort(([left], [right]) => left.localeCompare(right));
-      if (entries.length > 0) {
-        objectFingerprint = entries
-          .map(([key, value]) => `${key}:${String(value)}`)
-          .join('|');
-      }
-    }
-    const stableIdentity =
-      user?.id ||
-      user?.sub ||
-      username ||
-      objectFingerprint;
-    return `${provider}:${stableIdentity}`;
-  }
-
-  getActiveAccountEntry() {
-    if (!this.activeAccountId) return null;
-    return this.accounts.find((account) => account.id === this.activeAccountId) || null;
   }
 
   static pickToken(response) {
@@ -300,48 +201,16 @@ class ExtensionAuth {
       authDbgLog('[ExtensionAuth] Token received from login');
     }
 
-    const accountId = this.buildAccountId(user);
-    await this.updateAuthStatus(true, user, token || null, { accountId });
+    await this.updateAuthStatus(true, user, token || null);
 
     return { token: token || null, user, data };
   }
 
   /**
    * Signs out the current account.
-   * @param {{ clearAll?: boolean }} options - Pass clearAll=true to remove all stored accounts.
    */
-  async signOut(options = {}) {
-    const clearAll = Boolean(options.clearAll);
-
-    if (clearAll || this.accounts.length === 0) {
-      this.accounts = [];
-      this.activeAccountId = null;
-      await this.updateAuthStatus(false, null, null);
-      return;
-    }
-
-    const activeId = this.activeAccountId;
-    if (!activeId) {
-      this.accounts = [];
-      await this.updateAuthStatus(false, null, null);
-      return;
-    }
-
-    const remainingAccounts = this.accounts.filter((account) => account.id !== activeId);
-    this.accounts = remainingAccounts;
-
-    if (remainingAccounts.length === 0) {
-      this.activeAccountId = null;
-      await this.updateAuthStatus(false, null, null);
-      return;
-    }
-
-    const nextActive = remainingAccounts[0];
-    this.activeAccountId = nextActive.id;
-    await this.updateAuthStatus(true, nextActive.user, nextActive.token, {
-      accountId: nextActive.id,
-      keepAccounts: true,
-    });
+  async signOut() {
+    await this.updateAuthStatus(false, null, null);
   }
 
   async requestAuthStatus() {
@@ -352,38 +221,23 @@ class ExtensionAuth {
   async persistAuthState() {
     if (typeof chrome === 'undefined' || !chrome.storage?.local) return;
 
-    await chrome.storage.local.set({
-      auth_accounts: this.accounts,
-      auth_active_account_id: this.activeAccountId || null,
-    });
-
-    const active = this.getActiveAccountEntry();
-    const hasLegacySession = Boolean(active?.user && active?.token);
-
-    if (hasLegacySession) {
+    if (this.isAuthenticated && this.user && this.token) {
       await chrome.storage.local.set({
-        auth_user: active.user,
-        auth_token: active.token,
-        auth_timestamp: active.timestamp || Date.now(),
+        auth_user: this.user,
+        auth_token: this.token,
+        auth_timestamp: Date.now(),
       });
-      authDbgLog('[ExtensionAuth] Storing active account token in chrome.storage.local');
+      authDbgLog('[ExtensionAuth] Storing account token in chrome.storage.local');
       return;
     }
 
-    await chrome.storage.local.remove([
-      'auth_user',
-      'auth_token',
-      'auth_timestamp',
-      'firebase_user',
-    ]);
+    await this.clearSession();
   }
 
   async clearSession() {
     if (typeof chrome === 'undefined' || !chrome.storage?.local) return;
 
     await chrome.storage.local.remove([
-      'auth_accounts',
-      'auth_active_account_id',
       'auth_user',
       'auth_token',
       'auth_timestamp',
@@ -396,34 +250,8 @@ class ExtensionAuth {
     this.user = this.isAuthenticated ? user : null;
     this.token = this.isAuthenticated ? token || null : null;
 
-    if (this.isAuthenticated && this.user && this.token) {
-      const accountId = options.accountId || this.buildAccountId(this.user);
-      this.activeAccountId = accountId;
-
-      const existingIndex = this.accounts.findIndex((account) => account.id === accountId);
-      const nextEntry = {
-        id: accountId,
-        user: this.user,
-        token: this.token,
-        timestamp: Date.now(),
-      };
-
-      if (existingIndex >= 0) {
-        this.accounts[existingIndex] = nextEntry;
-      } else {
-        this.accounts.push(nextEntry);
-      }
-    } else if (options.keepAccounts !== true) {
-      this.accounts = [];
-      this.activeAccountId = null;
-    }
-
     if (options.persist !== false) {
-      if (this.isAuthenticated || options.keepAccounts === true) {
-        await this.persistAuthState();
-      } else {
-        await this.clearSession();
-      }
+      await this.persistAuthState();
     }
 
     if (!options.silent) {
@@ -442,8 +270,6 @@ class ExtensionAuth {
       isAuthenticated: this.isAuthenticated,
       user: this.user,
       token: this.token,
-      accounts: this.getAccounts(),
-      activeAccountId: this.activeAccountId,
     });
 
     return () => {
@@ -459,8 +285,6 @@ class ExtensionAuth {
       isAuthenticated: this.isAuthenticated,
       user: this.user,
       token: this.token,
-      accounts: this.getAccounts(),
-      activeAccountId: this.activeAccountId,
     };
 
     this.authStatusCallbacks.forEach((callback) => {
@@ -470,39 +294,6 @@ class ExtensionAuth {
         authDbgError('[ExtensionAuth] Auth callback failed:', error);
       }
     });
-  }
-
-  getAccounts() {
-    return this.accounts.map((account) => ({
-      id: account.id,
-      user: account.user,
-      timestamp: account.timestamp || null,
-    }));
-  }
-
-  async switchAccount(accountId) {
-    if (!accountId) {
-      throw new Error('Account ID is required to switch accounts. Please provide a valid account ID.');
-    }
-
-    const targetAccount = this.accounts.find((account) => account.id === accountId);
-    if (!targetAccount) {
-      throw new Error('Selected account not found.');
-    }
-
-    await this.updateAuthStatus(true, targetAccount.user, targetAccount.token, {
-      accountId: targetAccount.id,
-      keepAccounts: true,
-    });
-
-    return {
-      id: targetAccount.id,
-      user: {
-        username: targetAccount.user?.username || null,
-        email: targetAccount.user?.email || null,
-        displayName: targetAccount.user?.displayName || null,
-      },
-    };
   }
 
   getCurrentUser() {


### PR DESCRIPTION
## Description
   Removes multi-account support from the extension, simplifying auth to a
   single-session model (fewer moving parts, less surface area for bugs).
   Also fixes profile picture caching so it's persisted from the first
   render instead of being recomputed/refetched on every popup open.

   ## Type of Change
   - [x] Code refactoring
   - [x] Bug fix

   ## Testing
   - [x] Ran `node tests/auth.test.js` — all passing
   - [x] Tested popup functionality (sign in/out, avatar rendering) in Chrome
   - [x] No console errors

   ## Checklist
   - [x] Code follows project style guidelines
   - [x] Self-review completed
   - [x] No breaking changes